### PR TITLE
[Review] Added reading arrow::io::RandomAccessFile for read_csv

### DIFF
--- a/cpp/include/cudf/io_functions_cpp.h
+++ b/cpp/include/cudf/io_functions_cpp.h
@@ -1,0 +1,29 @@
+
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include "arrow/io/interfaces.h"
+#include "arrow/io/file.h"
+
+//I can't add the file_handle to args because args has to be compiled
+//for cffi
+gdf_error read_csv_arrow(csv_read_arg *args,
+		std::shared_ptr<arrow::io::RandomAccessFile> file_handle);
+
+

--- a/cpp/tests/io/csv/csv_test.cu
+++ b/cpp/tests/io/csv/csv_test.cu
@@ -25,6 +25,8 @@
 
 #include <cudf.h>
 #include <cudf/functions.h>
+#include <cudf/io_functions_cpp.h>
+#include <arrow/status.h>
  
 struct gdf_csv_test : public ::testing::Test {
   void TearDown() {
@@ -86,7 +88,11 @@ TEST(gdf_csv_test, CsvSimple)
 		args.skiprows 		= 0;
 		args.skipfooter 	= 0;
 		args.dayfirst 		= 0;
-
+		args.use_cols_int 	= NULL;
+		args.use_cols_char 	= NULL;
+        args.use_cols_char_len  = 0;
+        args.use_cols_int_len   = 0;
+        args.windowslinetermination = false;
 		error = read_csv(&args);
 	}
 
@@ -94,6 +100,68 @@ TEST(gdf_csv_test, CsvSimple)
 }
 
 
+TEST(gdf_csv_test, CsvSimpleRandomAccessFile)
+{
+
+	gdf_error error = GDF_SUCCESS;
+
+	csv_read_arg	args;
+
+    args.num_cols = 10;
+
+    args.names = new const char*[10] {
+    	"A",
+    	"B",
+    	"C",
+    	"D",
+    	"E",
+    	"F",
+    	"G",
+    	"H",
+    	"I",
+    	"J"
+    };
+
+    args.dtype = new const char *[10]{
+    		"int32",
+    		"int32",
+    		"int32",
+    		"int32",
+    		"int32",
+    		"int32",
+    		"int32",
+    		"int32",
+    		"int32",
+    		"int32"
+    };
+
+
+
+
+	std::shared_ptr<arrow::io::ReadableFile> readable_file;
+	EXPECT_TRUE(arrow::io::ReadableFile::Open(std::string("/tmp/simple.csv"), &readable_file).ok());
+
+
+
+	args.delimiter 		= ',';
+	args.lineterminator = '\n';
+	args.delim_whitespace = 0;
+	args.skipinitialspace = 0;
+	args.skiprows 		= 0;
+	args.skipfooter 	= 0;
+	args.dayfirst 		= 0;
+	args.use_cols_int 	= NULL;
+	args.use_cols_char 	= NULL;
+    args.use_cols_char_len  = 0;
+    args.use_cols_int_len   = 0;
+    args.windowslinetermination = false;
+	error = read_csv_arrow(&args,readable_file);
+
+
+	EXPECT_TRUE( error == GDF_SUCCESS );
+	EXPECT_TRUE( args.num_cols_out == 10);
+
+}
 
 TEST(gdf_csv_test, MortPerf)
 {


### PR DESCRIPTION
readuced the number of threads per block to 512 on the code that parses csv since on my machine each thread requires 103 registeres pre thread which was causing launch errors, added a new cpp api for reading parquet files from arrow::io::RandomAccessFile , fixed a bug in the csv reader test that would cause it to crash if it actually ran
